### PR TITLE
Changed to better work with Chipmunk 

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,8 @@ Example:
 
     cargo build
     cargo run 100
+
+To test run
+
+    cargo test
+

--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,2 +1,3 @@
 *.swp
 1
+test_prog_to_run.rs

--- a/src/alu.rs
+++ b/src/alu.rs
@@ -7,15 +7,15 @@ use crate::input_mux::InputMux;
 //Use a PHV Container as an object containing all states - *just for now*
 //return the previous states, unmodified or not
 
-
+pub type StateVar = i32;
 pub struct ALU{
     
     /*Packet containers from multiple muxs' are passed to an ALU, so should be a struct field and organized
     as a vector of containers compared to a PHV*/
     
     pub sequential_function :
-        Box <dyn Fn (&mut Vec<i32>,
-             &mut Vec<PhvContainer<i32> >) 
+        Box <dyn Fn (&mut Vec <StateVar>,
+                     &Vec <PhvContainer<i32> >) 
             -> Vec <i32> >,
     pub state_variables : Vec<i32>,
     pub input_muxes : Vec <InputMux> ,
@@ -26,19 +26,19 @@ pub struct ALU{
 impl ALU {
        
     pub fn new (function : Box <dyn Fn ( &mut Vec <i32>, 
-                                &mut Vec<PhvContainer<i32>>) 
+                                &Vec<PhvContainer<i32>>) 
                                 -> Vec <i32> >,
-            state_vars : Vec <i32>,
-            new_input_muxes: Vec <InputMux>,
-            new_output_mux : OutputMux,
-            stateful_alu : bool) 
+            t_state_variables : Vec <i32>,
+            t_input_muxes: Vec <InputMux>,
+            t_output_mux : OutputMux,
+            t_is_stateful : bool) 
             -> ALU {
 
       ALU { sequential_function : function,
-            state_variables: state_vars,
-            input_muxes: new_input_muxes,
-            output_mux : new_output_mux,
-            is_stateful : stateful_alu,
+            state_variables: t_state_variables,
+            input_muxes: t_input_muxes,
+            output_mux : t_output_mux,
+            is_stateful : t_is_stateful,
       
       }
     }
@@ -49,7 +49,7 @@ impl ALU {
     // packet values. Once function is run, phv value should
     // be passed to the output mux. 
 
-    pub fn run (&mut self, packet_fields: &mut Vec<PhvContainer<i32>>) -> Vec <i32> {
+    pub fn run (&mut self, packet_fields: &Vec<PhvContainer<i32>>) -> Vec <i32> {
 
       (self.sequential_function) 
           (&mut self.state_variables,
@@ -73,7 +73,7 @@ impl ALU {
         }
     }
     pub fn send_packets_to_output_mux(&mut self, mut values: Vec<i32>) {
-        self.output_mux.input_phv_containers.append(&mut values);   
+      self.output_mux.swap_input_phv_containers (&values);
     }  
     pub fn is_stateful (&self) -> bool {
         self.is_stateful

--- a/src/input_mux.rs
+++ b/src/input_mux.rs
@@ -1,6 +1,5 @@
 use crate::phv_container::PhvContainer;
 use crate::phv::Phv;
-use crate::alu::ALU;
 
 /* Option being used for an output_value because their is no
   output_value until the mux actually executes */
@@ -8,16 +7,16 @@ use crate::alu::ALU;
 #[derive(Clone)]
 pub struct InputMux{
     pub input_phv: Phv<i32>,
-    pub index: i32,
+    pub index : i32,
 }
 
 impl InputMux{
 
-    pub fn new(&self, input: Phv<i32>, i : i32) -> Self {
-        InputMux {input_phv : input, index : i}
+    pub fn new(&self, input: Phv<i32>, hole_index : i32) -> Self {
+        InputMux {input_phv : input, index : hole_index }
     
     }
     pub fn output(&self) -> PhvContainer<i32> {
-        self.input_phv[self.index].clone()   
+        self.input_phv [self.index].clone()
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,3 @@
-// extern crate druzhba;
 extern crate rand;
 
 mod program_to_run_akv;
@@ -6,9 +5,13 @@ mod program_to_run_akv;
 extern crate druzhba;
 
 use druzhba::output_mux::OutputMux;
+use druzhba::input_mux::InputMux;
 use druzhba::pipeline::Pipeline;
 use druzhba::phv::Phv;
 use druzhba::phv_container::PhvContainer;
+use druzhba::pipeline_stage::PipelineStage;
+use druzhba::alu::ALU;
+use druzhba::alu::StateVar;
 
 use rand::Rng;
 use std::env;
@@ -45,10 +48,15 @@ fn main() {
             }); 
         });
 
+    println! ("Input packet: {} ", packet);
     let new_packet : Phv<i32> = pipeline.tick (packet);
     if !new_packet.is_bubble() {
       println! ("Output packet: {} ", new_packet);
     }
   }
 }
+
+// Runs test in test.rs
+#[cfg(test)]
+mod test;
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,17 +5,15 @@ mod program_to_run_akv;
 
 extern crate druzhba;
 
+use druzhba::output_mux::OutputMux;
 use druzhba::pipeline::Pipeline;
 use druzhba::phv::Phv;
 use druzhba::phv_container::PhvContainer;
-use druzhba::pipeline_stage::PipelineStage;
 
-use std::collections::HashMap;
 use rand::Rng;
 use std::env;
 
 #[warn(unused_imports)]
-
 fn main() {
 
   let args : Vec<String> = env::args().collect();
@@ -30,7 +28,7 @@ fn main() {
     };
   assert! (ticks >= 1);
   let mut pipeline : Pipeline = program_to_run_akv::init_pipeline();
-  let num_containers : i32 = 10;
+  let num_containers : i32 = 1;
   // For every tick create a new packet with the 
   // specified input fields set to random values from
   // 0 to 100. Send packet through pipeline and 
@@ -41,18 +39,13 @@ fn main() {
     // Initializes packet with all of the input fields
     // along with a random value
     (0..num_containers)
-        .for_each ( |s| {
+        .for_each ( |_s| {
             packet.add_container_to_phv(PhvContainer {
-                field_value : rand::thread_rng().gen_range(0,100)
+                field_value : rand::thread_rng().gen_range(0,100),
             }); 
         });
 
-    println!("Input packet: {} ", packet);
-    // println!("Is bubble: {}", packet.is_bubble());
     let new_packet : Phv<i32> = pipeline.tick (packet);
-    // println!("Is bubble: {}", new_packet.is_bubble());
-    // println!("Value of first container in packet {}", new_packet.packets[0].field_value);
-
     if !new_packet.is_bubble() {
       println! ("Output packet: {} ", new_packet);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,14 +4,10 @@ mod program_to_run_akv;
 
 extern crate druzhba;
 
-use druzhba::output_mux::OutputMux;
-use druzhba::input_mux::InputMux;
 use druzhba::pipeline::Pipeline;
 use druzhba::phv::Phv;
 use druzhba::phv_container::PhvContainer;
-use druzhba::pipeline_stage::PipelineStage;
 use druzhba::alu::ALU;
-use druzhba::alu::StateVar;
 
 use rand::Rng;
 use std::env;

--- a/src/output_mux.rs
+++ b/src/output_mux.rs
@@ -1,23 +1,21 @@
 use crate::phv_container::PhvContainer;
-use crate::phv::Phv;
-use crate::alu::ALU;
 
 #[derive(Clone)]
 pub struct OutputMux{
-    pub input_phv_containers: Vec<PhvContainer<i32>>,
+    pub input_phv_containers: Vec<i32>,
     pub index: i32
 }
 
 impl OutputMux{
 
-    pub fn new(&self, input: Vec<PhvContainer<i32>>, i : i32) -> Self {
+    pub fn new(&self, input: Vec<i32>, i : i32) -> Self {
         OutputMux {input_phv_containers : input, index: i}
     }
     
     /*Add a Phv Container to the list of
      input PHV Containers supplied to the OutputMux*/
 
-    pub fn add_phv_container(&mut self, phv_cont : PhvContainer<i32>) {
+    pub fn add_phv_container(&mut self, phv_cont : i32) {
         self.input_phv_containers.push(phv_cont);
     }
     
@@ -25,6 +23,11 @@ impl OutputMux{
      from a list of them */
 
     pub fn output(&self) -> PhvContainer<i32>{
-        self.input_phv_containers[self.index as usize].clone()
+        if self.input_phv_containers.len() == 0{
+            panic!("Error: This output mux has no inputs");
+        }
+        PhvContainer {
+            field_value : self.input_phv_containers[self.index as usize].clone()
+        }
     }
 }

--- a/src/output_mux.rs
+++ b/src/output_mux.rs
@@ -18,6 +18,9 @@ impl OutputMux{
     pub fn add_phv_container(&mut self, phv_cont : i32) {
         self.input_phv_containers.push(phv_cont);
     }
+    pub fn swap_input_phv_containers (&mut self, t_phv_containers : &Vec <i32>){
+      self.input_phv_containers = t_phv_containers.clone();
+    }
     
     /*  Use input index, to return a single PHV Container
      from a list of them */

--- a/src/phv.rs
+++ b/src/phv.rs
@@ -1,6 +1,5 @@
 use crate::phv_container::PhvContainer;
-use std::collections::HashMap;
-use std::ops::{Index, IndexMut, AddAssign};
+use std::ops::{Index, IndexMut};
 use std::fmt;
 
 
@@ -62,9 +61,9 @@ impl<T> IndexMut<i32> for Phv<T> {
 impl<T> fmt::Display for Phv<T> where T : fmt::Display {
 
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-      let mut s : String = String::from(""); 
+      let s : String = String::from(""); 
       let mut counter = 0;
-      for container in &self.packets {
+      for _container in &self.packets {
         write!(f, "\nindex : {}, value : {}\n", &counter.to_string(), &self.packets[counter].field_value.to_string());
         counter += 1;
       }

--- a/src/phv_container.rs
+++ b/src/phv_container.rs
@@ -9,7 +9,7 @@ impl<T> PhvContainer<T> where T : Clone {
   pub fn new (value: T) -> Self{
       PhvContainer{ field_value: value, }
   }
-  pub fn get_value(self) -> T {
+  pub fn get_value(&self) -> T {
       self.field_value.clone()
   }
 }

--- a/src/phv_container.rs
+++ b/src/phv_container.rs
@@ -1,16 +1,15 @@
-  use std::clone::Clone;
 
-  #[derive(Clone, Default)]
-    pub struct PhvContainer <T> {
-      /*PHV Containers do not have names, just indexes in the PHV*/
-      pub field_value: T
-    }
+#[derive(Clone)]
+pub struct PhvContainer <T> {
+  /*PHV Containers do not have names, just indexes in the PHV*/
+  pub field_value: T,
+}
 
-    impl<T> PhvContainer<T> {
-      pub fn new (value: T) -> Self{
-          PhvContainer{field_value: value}
-      }
-      pub fn getValue(self) -> T {
-          self.field_value
-      }
-    }
+impl<T> PhvContainer<T> where T : Clone {
+  pub fn new (value: T) -> Self{
+      PhvContainer{ field_value: value, }
+  }
+  pub fn get_value(self) -> T {
+      self.field_value.clone()
+  }
+}

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -35,6 +35,9 @@ impl Pipeline {
     Pipeline { pipeline_stages : t_pipeline_stages, old_phvs: old_phv, new_phvs: new_phv }
   }
 
+  pub fn len (&self) -> usize {
+    self.pipeline_stages.len()
+  }
   pub fn tick (&mut self, t_packet : Phv<i32>) -> Phv<i32> {
     if self.pipeline_stages.len() == 1{
       assert!(self.old_phvs.len() == 0 && self.new_phvs.len() == 0);
@@ -42,6 +45,7 @@ impl Pipeline {
       self.pipeline_stages[0].tick(t_packet)
     }
     else{
+    
       self.new_phvs.insert(0, self.pipeline_stages[0].tick(t_packet.clone()));
       for x in 1..self.pipeline_stages.len() - 1 {
         self.new_phvs.insert(x, self.pipeline_stages[x].tick(self.old_phvs[&(x-1)].clone()));
@@ -50,7 +54,7 @@ impl Pipeline {
       let length : usize = self.pipeline_stages.len();
 
       let last_phv = self.pipeline_stages[length - 1].tick(self.old_phvs[&(length - 2)].clone());
-      
+
       mem::swap(&mut self.new_phvs, &mut self.old_phvs);
       last_phv
     }

--- a/src/pipeline.rs
+++ b/src/pipeline.rs
@@ -36,8 +36,9 @@ impl Pipeline {
   }
 
   pub fn tick (&mut self, t_packet : Phv<i32>) -> Phv<i32> {
-    if(self.pipeline_stages.len() == 1){
+    if self.pipeline_stages.len() == 1{
       assert!(self.old_phvs.len() == 0 && self.new_phvs.len() == 0);
+      
       self.pipeline_stages[0].tick(t_packet)
     }
     else{
@@ -46,10 +47,11 @@ impl Pipeline {
         self.new_phvs.insert(x, self.pipeline_stages[x].tick(self.old_phvs[&(x-1)].clone()));
       }
 
-      let last_phv = self.pipeline_stages[self.pipeline_stages.len() - 1].tick(self.old_phvs[&(self.pipeline_stages.len() - 2)].clone());
+      let length : usize = self.pipeline_stages.len();
+
+      let last_phv = self.pipeline_stages[length - 1].tick(self.old_phvs[&(length - 2)].clone());
       
       mem::swap(&mut self.new_phvs, &mut self.old_phvs);
-      
       last_phv
     }
   }
@@ -59,7 +61,7 @@ impl Pipeline {
 impl fmt::Display for Pipeline{
 
   fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-      let mut s : String = String::from(""); 
+      let s : String = String::from(""); 
       write!(f, "Old Phvs: \n");
       for (key, value) in &self.old_phvs {
         write!(f, "stage {} : \n{}\n", key, value);

--- a/src/pipeline_stage.rs
+++ b/src/pipeline_stage.rs
@@ -4,60 +4,73 @@ use crate::phv::Phv;
 use crate::alu::ALU;
 use crate::phv_container::PhvContainer;
 
-use std::collections::HashMap;
 use self::rand::{thread_rng, Rng};
 
-
-#[derive(Clone)]
+//#[derive(Clone)]
 pub struct PipelineStage {
-   pub atoms : Vec<ALU>,
+   pub stateless_atoms : Vec<ALU>,
+   pub stateful_atoms : Vec<ALU>,
 }
 
 impl PipelineStage {
   pub fn new () -> Self {
-    let vec_of_atoms : Vec <ALU> = Vec::new();
-    PipelineStage { atoms : vec_of_atoms }
+    PipelineStage { stateless_atoms : Vec::new(),
+                    stateful_atoms : Vec::new(), }
   }
-  pub fn with_atoms (vec_of_atoms : Vec <ALU> ) -> Self{
-    PipelineStage { atoms : vec_of_atoms }
-  }
-  pub fn add_atom (&mut self, t_alu : ALU) {
-    self.atoms.push (t_alu)
+  pub fn with_atoms (stateless : Vec <ALU>, stateful : Vec<ALU>) -> Self{
+    PipelineStage { stateless_atoms : stateless,
+                    stateful_atoms : stateful, 
+    }
   }
 
   // Iterates through all atoms stored and calls their 
   // underlying function on the incoming Phv in 
   // random order. Pass the mutated phv containers to their respective muxes.
-  pub fn tick(&self, input_phv: Phv<i32>) -> Phv<i32>{ 
+  pub fn tick(&mut self, input_phv: Phv<i32>) -> Phv<i32>{ 
 
-      if (input_phv.is_bubble()) {
-          Phv::new()
+      if input_phv.is_bubble() {
+        Phv::new()
       }
       else{
       
-      let mut output_phv : Phv<i32> = Phv {bubble : false, packets: Vec::new() };
-      let mut tmp_atoms : Vec <ALU> = self.atoms.clone();
-      thread_rng().shuffle(&mut tmp_atoms);
+        let mut output_phv : Phv<i32> = 
+            Phv { bubble : false, 
+                  packets: Vec::new() };
+        thread_rng().shuffle(&mut self.stateful_atoms);
+        thread_rng().shuffle(&mut self.stateless_atoms);
 
-      for atom in tmp_atoms.iter_mut() {
+        let mut old_state : Vec <i32> = Vec::new();
+        // Need old state variables first to put them
+        // into output muxes later
+        for atom in self.stateful_atoms.iter_mut () {
+          atom.send_packets_to_input_muxes(input_phv.clone());
+          let mut packet_fields : Vec<PhvContainer<i32>> = atom.input_mux_output();
+          for elem in atom.run (&mut packet_fields){
+            old_state.push (elem);
+          }
+        }
+        let results : Vec <i32> = Vec::new();
+        // Gets return values from the ALUs and inserts
+        // them into output muxes along with old state vars
+        for atom in self.stateless_atoms.iter_mut() {
         
-        //PHV is passed to it's corresponding input mux, and
-        //a single container is outputted. Container is put
-        //into a vector and passed to atom
-        atom.send_packets_to_input_mux(input_phv.clone());
-        let output_of_input_mux : PhvContainer<i32> = atom.input_mux_output();
-        let mut packet_fields : Vec<PhvContainer<i32>> = vec![output_of_input_mux];
-        
-        //After being passed to atom, value is sent to an
-        //output mux and put into a PHV
-        atom.run(&mut packet_fields);
-        atom.send_packets_to_output_mux(packet_fields);
-        output_phv.add_container_to_phv(atom.output_mux.output());
-      }
+          //PHV is passed to it's corresponding input mux, and
+          //a single container is outputted. Container is put
+          //into a vector and passed to atom
+          atom.send_packets_to_input_muxes(input_phv.clone());
+          let mut packet_fields : Vec<PhvContainer<i32>> = 
+              atom.input_mux_output();
+          //After being passed to atom, value is sent to an
+          //output mux and put into a PHV
 
-      output_phv
-
+          let result : i32 =  atom.run(&mut packet_fields)[0];
+          // State variables and returned value from stateless ALU
+          let mut output_mux_fields : Vec <i32> = old_state.clone();
+          output_mux_fields.push (result);
+          atom.send_packets_to_output_mux(output_mux_fields);
+          output_phv.add_container_to_phv(atom.output_mux.output());
+        }
+        output_phv
       }
-  
     }
   }

--- a/src/pipeline_stage.rs
+++ b/src/pipeline_stage.rs
@@ -28,6 +28,7 @@ impl PipelineStage {
   // random order. Pass the mutated phv containers to their respective muxes.
   pub fn tick(&mut self, input_phv: Phv<i32>) -> Phv<i32>{ 
 
+//      println!("Working on this input phv {}", input_phv);
       if input_phv.is_bubble() {
         Phv::new()
       }
@@ -63,13 +64,19 @@ impl PipelineStage {
           //After being passed to atom, value is sent to an
           //output mux and put into a PHV
 
-          let result : i32 =  atom.run(&mut packet_fields)[0];
+          let result : i32 =  atom.run(&packet_fields)[0];
           // State variables and returned value from stateless ALU
           let mut output_mux_fields : Vec <i32> = old_state.clone();
+
           output_mux_fields.push (result);
+
+/*          println!("INPUT PHV: {}", input_phv);
+          println!("PAssing {:?} into output mux", output_mux_fields);
+          println!("RESULT: {}", result);*/
           atom.send_packets_to_output_mux(output_mux_fields);
           output_phv.add_container_to_phv(atom.output_mux.output());
         }
+//        println!("OUTPUT PHV {}", output_phv);
         output_phv
       }
     }

--- a/src/prog_to_run.rs
+++ b/src/prog_to_run.rs
@@ -9,7 +9,6 @@ use std::collections::HashMap;
 
 pub type StateScalar = PhvContainer <i32>;
 pub type StateArray = PhvContainer <Vec <i32> >;
-
 // Test ALUs to be used in pipeline that mutate
 // Phv, StateScalar, and StateArray
 fn atom0 (packet : &mut Phv, 

--- a/src/program_to_run_akv.rs
+++ b/src/program_to_run_akv.rs
@@ -9,18 +9,17 @@ use std::collections::HashMap;
 
 
 //Stateless ALU
-pub fn alu_stateless_fn(  state_vars: &mut HashMap<String, i32>,
-                packet : &mut Vec<PhvContainer<i32>>  ){
+pub fn alu_stateless_fn(  _state_vars: &mut Vec<i32>,
+                packet : &mut Vec<PhvContainer<i32>>) -> Vec <i32>{
 
-        packet[0].field_value = packet[0].field_value * 2;
-       
+    vec! [packet[0].field_value * 21]
 }
 
-pub fn alu_stateful_fn(  state_vars: &mut HashMap<String, i32>,
-                packet : &mut Vec<PhvContainer<i32>>  ){
-
-        packet[0].field_value = packet[0].field_value * 3;
-        *state_vars.get_mut("count").unwrap() += 1;
+pub fn alu_stateful_fn(  state_vars: &mut Vec<i32>,
+                packet : &mut Vec<PhvContainer<i32>>) -> Vec <i32>{
+    let old_state : Vec <i32> = state_vars.clone();
+    state_vars [0] = 21;
+    old_state
 }
 
 
@@ -30,19 +29,19 @@ pub fn init_pipeline() -> Pipeline {
     /*Holes provided by *Chipmunk* for input and output muxes of two stages. */
     
     let alu_one_one_input_mux_index_hole = 0 ;
-    let alu_one_two_input_mux_index_hole = 1 ;
-    let alu_one_one_output_mux_index_hole = 0 ;
-    let alu_one_two_output_mux_index_hole = 0 ;
+    let alu_one_two_input_mux_index_hole = 0 ;
+    let alu_one_one_output_mux_index_hole = 2 ;
+    let alu_one_two_output_mux_index_hole = 2 ;
 
     let alu_two_one_input_mux_index_hole = 0 ;
-    let alu_two_two_input_mux_index_hole = 1 ;
-    let alu_two_one_output_mux_index_hole = 0 ;
-    let alu_two_two_output_mux_index_hole = 0 ;
+    let alu_two_two_input_mux_index_hole = 0 ;
+    let alu_two_one_output_mux_index_hole = 2 ;
+    let alu_two_two_output_mux_index_hole = 2 ;
 
     //arbitrary state variables
-    let mut state_vars : HashMap<String,i32> = HashMap::new();
-    state_vars.insert("count".to_string(), 1);
-    state_vars.insert("arbitrary".to_string(), 1);
+    let mut state_vars : Vec<i32> = Vec::new();
+    state_vars.push (0);
+    state_vars.push(1);
 
 
     /* Stage 1 */
@@ -50,34 +49,65 @@ pub fn init_pipeline() -> Pipeline {
 
     //generate input and output muxes for both ALUs in the first stage
     
-    let alu_one_one_input_mux : InputMux = InputMux{input_phv: first_phv.clone() , index : alu_one_one_input_mux_index_hole};
-    let alu_one_two_input_mux : InputMux= InputMux{input_phv: first_phv.clone() , index : alu_one_two_input_mux_index_hole};
+    let alu_one_one_input_muxes : Vec<InputMux> = 
+        vec![InputMux {input_phv: first_phv.clone() , index : alu_one_one_input_mux_index_hole}];
+    let alu_one_two_input_muxes : Vec<InputMux> = 
+        vec![InputMux{input_phv: first_phv.clone() , index : alu_one_two_input_mux_index_hole}];
     let alu_one_one_output_mux : OutputMux = OutputMux{input_phv_containers: Vec::new() , index: alu_one_one_output_mux_index_hole};
+
     let alu_one_two_output_mux : OutputMux = OutputMux{input_phv_containers: Vec::new() , index: alu_one_two_output_mux_index_hole};
 
     //generate ALUs for first pipeline stage
    
-    let alu_one_one : ALU = ALU{sequential_function: alu_stateless_fn, state_variables: state_vars.clone(), input_mux: alu_one_one_input_mux, output_mux: alu_one_one_output_mux};
-    let alu_one_two : ALU = ALU{sequential_function: alu_stateless_fn, state_variables: state_vars.clone(), input_mux: alu_one_two_input_mux, output_mux: alu_one_two_output_mux};
+    let alu_one_one : ALU = 
+        ALU { sequential_function: Box::new(alu_stateful_fn), 
+              state_variables: state_vars.clone(), 
+              input_muxes: alu_one_one_input_muxes, 
+              output_mux: alu_one_one_output_mux, 
+              is_stateful : false };
+    let alu_one_two : ALU = 
+        ALU { sequential_function: Box::new(alu_stateless_fn), 
+              state_variables: Vec::new(), 
+              input_muxes: alu_one_two_input_muxes, 
+              output_mux: alu_one_two_output_mux, 
+              is_stateful : false };
     
-    let pipeline_stage_one : PipelineStage = PipelineStage{ atoms: vec![alu_one_one, alu_one_two] };
+    let pipeline_stage_one : PipelineStage = PipelineStage{ 
+        stateful_atoms: vec![alu_one_one], 
+        stateless_atoms : vec![alu_one_two] };
 
     /* Stage 2 */
     let second_phv : Phv<i32> = Phv {bubble: true, packets: Vec::new()};
 
     //generate input and output muxes for both ALUs in the second stage
     
-    let alu_two_one_input_mux : InputMux = InputMux{input_phv: second_phv.clone() , index : alu_two_one_input_mux_index_hole};
-    let alu_two_two_input_mux : InputMux = InputMux{input_phv: second_phv.clone() , index : alu_two_two_input_mux_index_hole};
+    let alu_two_one_input_muxes : Vec<InputMux> = 
+        vec![InputMux{input_phv: second_phv.clone() , index : alu_two_one_input_mux_index_hole}];
+    let alu_two_two_input_muxes : Vec<InputMux> = 
+        vec![InputMux{input_phv: second_phv.clone() , index : alu_two_two_input_mux_index_hole}];
     let alu_two_one_output_mux : OutputMux = OutputMux{input_phv_containers: Vec::new() , index: alu_two_one_output_mux_index_hole};
     let alu_two_two_output_mux : OutputMux = OutputMux{input_phv_containers: Vec::new() , index: alu_two_two_output_mux_index_hole};
 
     //generate ALUs for second pipeline stage
     
-    let alu_two_one : ALU = ALU{sequential_function: alu_stateless_fn, state_variables: state_vars.clone(), input_mux: alu_two_one_input_mux, output_mux: alu_two_one_output_mux};
-    let alu_two_two : ALU = ALU{sequential_function: alu_stateless_fn, state_variables: state_vars.clone(), input_mux: alu_two_two_input_mux, output_mux: alu_two_two_output_mux};
+    let alu_two_one : ALU = 
+        ALU { sequential_function: Box::new(alu_stateful_fn), 
+              state_variables: state_vars.clone(), 
+              input_muxes : alu_two_one_input_muxes, 
+              output_mux: alu_two_one_output_mux, 
+              is_stateful : false };
+    let alu_two_two : ALU = 
+        ALU { sequential_function: Box::new(alu_stateless_fn), 
+              state_variables: Vec::new(), 
+              input_muxes : alu_two_two_input_muxes, 
+              output_mux: alu_two_two_output_mux, 
+              is_stateful: false 
+        };
 
-    let pipeline_stage_two : PipelineStage = PipelineStage{atoms: vec![alu_two_one, alu_two_two]};
+    let pipeline_stage_two : PipelineStage = PipelineStage{
+        stateful_atoms: vec![alu_two_one], 
+        stateless_atoms: vec![alu_two_two]
+    };
 
     //generate pipeline
 


### PR DESCRIPTION
Fixed compiler warnings and changed alu, mux, and pipeline architecture to better conform to the Chipmunk generated Sketch code. This is so that when the Chipmunk hole configurations are received, they will be able to retain their meanings. Also the alu function format needed to match the generated Rust code.