### PR TITLE
Smoother Druzhba build process

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ benches/blue_increase_unoptimized.rs
 benches/flowlets_unoptimized.rs
 benches/learn_filter_unoptimized.rs
 benches/rcp_unoptimized.rs
+
+build

--- a/README.md
+++ b/README.md
@@ -25,7 +25,11 @@ won't compile.
 
 To run these tests:
 
-    cargo test
+    ./build_dgen && cargo test
+
+To run benchmarks:
+
+    ./build_dgen && cargo bench
 
 Similarly, the dgen tests ensure that the alu grammar
 is being parsed correctly and that the ast is being

--- a/README.md
+++ b/README.md
@@ -25,11 +25,11 @@ won't compile.
 
 To run these tests:
 
-    ./build_dgen && cargo test
+    ./build_dgen.sh && cargo test
 
 To run benchmarks:
 
-    ./build_dgen && cargo bench
+    ./build_dgen.sh && cargo bench
 
 Similarly, the dgen tests ensure that the alu grammar
 is being parsed correctly and that the ast is being

--- a/build.rs
+++ b/build.rs
@@ -8,7 +8,7 @@ use std::process::Command;
 // into test_case_names and fill out the necessary data
 // in dgen_data
 fn main() { 
-    
+   
   let out_dir = String::from("src/");
   let destination = Path::new(&out_dir).join("test_with_chipmunk.rs");
   let mut test_file = File::create(&destination).unwrap();
@@ -125,6 +125,19 @@ fn run_dgen (test_case_names : &Vec<String>,
            .output()
            .expect("Adding execution permissions to dgen_bin failed");
   let mut index : usize = 0;
+  // Initializes a prog_to_run just so that Druzhba can compile
+  Command::new("./dgen_bin")
+              .arg("simple") // Name
+              .arg("example_alus/stateful_alus/raw.alu") // Stateful ALU
+              .arg("example_alus/stateless_alus/stateless_alu.alu") // Stateless ALU
+              .arg("2") // Depth
+              .arg("2") // Width
+              .arg("1") // Stateful ALUs
+              .arg("0,1,2,3") // constant vec
+              .arg("src/prog_to_run.rs")
+              .output()
+              .expect("Error running dgen");
+
   for arg in dgen_args.iter(){
     // Optimization level 1
     Command::new("./dgen_bin")

--- a/build_dgen.sh
+++ b/build_dgen.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+cd dgen && cargo build && cd ..

--- a/execute_simulator.py
+++ b/execute_simulator.py
@@ -113,6 +113,8 @@ def main ():
     args.append(str(raw_args.ticks))
     opt_level = raw_args.opt_level
     args.append(str(opt_level))
+    subprocess.run(['./build_dgen.sh'])
+
     if opt_level == 0:
 
         run_dgen_unoptimized(args)


### PR DESCRIPTION
execute_simulator.py and build.rs builds dgen first before running Druzhba to prevent compiler error. Add build_dgen.sh script to be run before cargo test and cargo bench to ensure that dgen binary exists before use.